### PR TITLE
feat(qibla): immersive camera-based Qibla alignment flow with alignment hook

### DIFF
--- a/app/(tabs)/qibla.tsx
+++ b/app/(tabs)/qibla.tsx
@@ -1,63 +1,40 @@
-import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as Haptics from 'expo-haptics';
-import * as Location from 'expo-location';
-import { Stack, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, Linking, Pressable, StyleSheet, View } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import { Linking, View } from 'react-native';
 
 import { QiblaCompassPage } from '@/components/qibla/qibla-compass-page';
-import { QiblaMapPage } from '@/components/qibla/qibla-map-page';
-import { ThemedText } from '@/components/themed-text';
+import { useQiblaAlignment } from '@/hooks/use-qibla-alignment';
 import { useSafeCameraPermissions } from '@/hooks/use-safe-camera-permissions';
-import {
-  PRAYER_LOCATION_PRESETS,
-  PRAYER_LOCATION_STORAGE_KEY,
-  type SavedPrayerLocation,
-} from '@/lib/islam-prayer-location';
-import { getDistanceToKaabaKm, getQiblaBearing } from '@/lib/qibla';
+
 const CALIBRATION_STEP_DEGREES = 2;
 
-type QiblaSubtab = 'compass' | 'map';
+function toTitleCase(value: string) {
+  return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export default function QiblaScreen() {
   const router = useRouter();
-  const needleRotation = useRef(new Animated.Value(0)).current;
-  const cumulativeRotation = useRef(0);
   const hasAutoRequestedCamera = useRef(false);
-
   const [cameraPermission, requestCameraPermission] = useSafeCameraPermissions();
   const [isRequestingCameraPermission, setIsRequestingCameraPermission] = useState(false);
 
-  const [activeSubtab, setActiveSubtab] = useState<QiblaSubtab>('compass');
-  const activeSubtabRef = useRef<QiblaSubtab>('compass');
-  const [locationText, setLocationText] = useState('Location access required');
-  const [locationError, setLocationError] = useState<string | null>(null);
-  const [locationPermissionStatus, setLocationPermissionStatus] =
-    useState<Location.PermissionStatus | null>(null);
-  const [areLocationServicesEnabled, setAreLocationServicesEnabled] = useState<boolean | null>(
-    null,
-  );
-  const [canAskLocationPermission, setCanAskLocationPermission] = useState(true);
-  const [locationPermissionRequestCount, setLocationPermissionRequestCount] = useState(0);
-  const [isRequestingLocationPermission, setIsRequestingLocationPermission] = useState(false);
-  const [coords, setCoords] = useState<Location.LocationObjectCoords | null>(null);
-  const [heading, setHeading] = useState<number>(0);
-  const [manualHeadingOffset, setManualHeadingOffset] = useState(0);
-  const [savedPrayerLocation, setSavedPrayerLocation] = useState<SavedPrayerLocation | null>(null);
+  const { prayerName } = useLocalSearchParams<{ prayerName?: string }>();
+  const prayerLabel = prayerName ? `${toTitleCase(prayerName)} Prayer` : 'Maghrib Prayer';
 
-  useEffect(() => {
-    activeSubtabRef.current = activeSubtab;
-  }, [activeSubtab]);
+  const {
+    alignmentOffset,
+    signedOffset,
+    alignmentState,
+    manualHeadingOffset,
+    recenter,
+    nudgeCalibration,
+  } = useQiblaAlignment();
 
   const cameraPermissionStatus = cameraPermission?.status ?? null;
   const canAskCameraPermission = cameraPermission?.canAskAgain ?? true;
-  const showLiveCamera = activeSubtab === 'compass' && cameraPermissionStatus === 'granted';
+  const showLiveCamera = cameraPermissionStatus === 'granted';
 
   useEffect(() => {
-    if (activeSubtab !== 'compass') {
-      return;
-    }
-
     if (hasAutoRequestedCamera.current) {
       return;
     }
@@ -69,291 +46,7 @@ export default function QiblaScreen() {
         setIsRequestingCameraPermission(false);
       });
     }
-  }, [activeSubtab, cameraPermissionStatus, requestCameraPermission]);
-
-  const prayerCoords = useMemo(() => {
-    if (coords) {
-      return coords;
-    }
-    if (savedPrayerLocation) {
-      return {
-        latitude: savedPrayerLocation.latitude,
-        longitude: savedPrayerLocation.longitude,
-      };
-    }
-    return null;
-  }, [coords, savedPrayerLocation]);
-
-  const prayerLocationLabel = useMemo(() => {
-    if (coords) {
-      return locationText;
-    }
-    if (savedPrayerLocation) {
-      return savedPrayerLocation.label;
-    }
-    return null;
-  }, [coords, locationText, savedPrayerLocation]);
-
-  const qiblaBearing = useMemo(() => {
-    if (!prayerCoords) {
-      return null;
-    }
-    return getQiblaBearing(prayerCoords.latitude, prayerCoords.longitude);
-  }, [prayerCoords]);
-
-  const distanceKm = useMemo(() => {
-    if (!prayerCoords) {
-      return null;
-    }
-    return getDistanceToKaabaKm(prayerCoords.latitude, prayerCoords.longitude);
-  }, [prayerCoords]);
-
-  const effectiveHeading = useMemo(
-    () => normalizeDegrees(heading + manualHeadingOffset),
-    [heading, manualHeadingOffset],
-  );
-
-  const relativeNeedleHeading = useMemo(() => {
-    if (qiblaBearing === null) {
-      return 0;
-    }
-    return normalizeDegrees(qiblaBearing - effectiveHeading);
-  }, [effectiveHeading, qiblaBearing]);
-
-  const alignmentDelta = useMemo(() => {
-    if (qiblaBearing === null) {
-      return null;
-    }
-    return Math.abs(((((qiblaBearing - effectiveHeading) % 360) + 540) % 360) - 180);
-  }, [effectiveHeading, qiblaBearing]);
-
-  const isAligned = alignmentDelta !== null && alignmentDelta <= 10;
-
-  const accuracyText = useMemo(() => {
-    if (!coords?.accuracy) {
-      return 'Locating accuracy';
-    }
-    if (coords.accuracy <= 20) {
-      return 'GPS verified';
-    }
-    if (coords.accuracy <= 80) {
-      return 'Moderate accuracy';
-    }
-    return 'Low accuracy';
-  }, [coords?.accuracy]);
-
-  const loadSavedPrayerLocation = React.useCallback(async () => {
-    try {
-      const stored = await AsyncStorage.getItem(PRAYER_LOCATION_STORAGE_KEY);
-      if (!stored) {
-        setSavedPrayerLocation(null);
-        return;
-      }
-
-      const parsed = JSON.parse(stored) as Partial<SavedPrayerLocation>;
-      if (
-        typeof parsed.id !== 'string' ||
-        typeof parsed.label !== 'string' ||
-        typeof parsed.latitude !== 'number' ||
-        typeof parsed.longitude !== 'number'
-      ) {
-        setSavedPrayerLocation(null);
-        return;
-      }
-
-      setSavedPrayerLocation({
-        id: parsed.id,
-        label: parsed.label,
-        latitude: parsed.latitude,
-        longitude: parsed.longitude,
-      });
-    } catch {
-      setSavedPrayerLocation(null);
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadSavedPrayerLocation();
-  }, [loadSavedPrayerLocation]);
-
-  useEffect(() => {
-    let mounted = true;
-    let headingSubscription: Location.LocationSubscription | null = null;
-
-    const loadLocation = async () => {
-      try {
-        let permission = await Location.getForegroundPermissionsAsync();
-        if (
-          permission.status !== 'granted' &&
-          locationPermissionRequestCount > 0 &&
-          permission.canAskAgain
-        ) {
-          setIsRequestingLocationPermission(true);
-          permission = await Location.requestForegroundPermissionsAsync();
-        }
-        if (!mounted) {
-          return;
-        }
-
-        setIsRequestingLocationPermission(false);
-        setLocationPermissionStatus(permission.status);
-        setCanAskLocationPermission(permission.canAskAgain);
-
-        if (permission.status !== 'granted') {
-          setAreLocationServicesEnabled(null);
-          setCoords(null);
-          setLocationError(
-            permission.canAskAgain
-              ? 'Location permission is required to calculate Qibla from your position.'
-              : 'Location permission is blocked. Enable location access in settings.',
-          );
-          setLocationText('Permission required');
-          return;
-        }
-
-        setLocationError(null);
-        setLocationText('Locating...');
-
-        const servicesEnabled = await Location.hasServicesEnabledAsync();
-        if (!mounted) {
-          return;
-        }
-
-        setAreLocationServicesEnabled(servicesEnabled);
-
-        if (!servicesEnabled) {
-          setCoords(null);
-          setLocationError('Location services are disabled. Enable location in device settings.');
-          setLocationText('Location services off');
-          return;
-        }
-
-        let current;
-        try {
-          current = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.Balanced,
-          });
-        } catch (positionError) {
-          if (!mounted) {
-            return;
-          }
-          const errorMessage =
-            positionError instanceof Error ? positionError.message : String(positionError);
-          if (errorMessage.includes('unsatisfied device settings')) {
-            setLocationError('Location services are disabled. Enable location in device settings.');
-            setLocationText('Location services off');
-          } else {
-            setLocationError('Unable to determine your location. Check device settings.');
-            setLocationText('Location unavailable');
-          }
-          return;
-        }
-
-        if (!mounted) {
-          return;
-        }
-
-        setCoords(current.coords);
-
-        try {
-          const reverse = await Location.reverseGeocodeAsync({
-            latitude: current.coords.latitude,
-            longitude: current.coords.longitude,
-          });
-          if (!mounted) {
-            return;
-          }
-          if (reverse.length > 0) {
-            const place = reverse[0];
-            setLocationText(
-              [place.city, place.region, place.country]
-                .filter((value): value is string => Boolean(value))
-                .join(', ') || 'Current location',
-            );
-          } else {
-            setLocationText(
-              `${current.coords.latitude.toFixed(3)}, ${current.coords.longitude.toFixed(3)}`,
-            );
-          }
-        } catch {
-          if (mounted) {
-            setLocationText(
-              `${current.coords.latitude.toFixed(3)}, ${current.coords.longitude.toFixed(3)}`,
-            );
-          }
-        }
-
-        const initialHeading = await Location.getHeadingAsync();
-        const bestHeading =
-          initialHeading.trueHeading >= 0 ? initialHeading.trueHeading : initialHeading.magHeading;
-
-        if (mounted && activeSubtabRef.current === 'compass') {
-          setHeading(bestHeading);
-        }
-
-        headingSubscription = await Location.watchHeadingAsync((headingUpdate) => {
-          if (!mounted || activeSubtabRef.current !== 'compass') {
-            return;
-          }
-          const liveHeading =
-            headingUpdate.trueHeading >= 0 ? headingUpdate.trueHeading : headingUpdate.magHeading;
-          setHeading(liveHeading);
-        });
-      } catch (error) {
-        console.error('Failed to load Qibla data:', error);
-        if (mounted) {
-          setIsRequestingLocationPermission(false);
-          setLocationError('Unable to read location and compass data on this device.');
-          setLocationText('Unavailable');
-        }
-      }
-    };
-
-    void loadLocation();
-
-    return () => {
-      mounted = false;
-      headingSubscription?.remove();
-    };
-  }, [locationPermissionRequestCount]);
-
-  useEffect(() => {
-    let delta = relativeNeedleHeading - (cumulativeRotation.current % 360);
-    if (delta > 180) delta -= 360;
-    if (delta < -180) delta += 360;
-    cumulativeRotation.current += delta;
-
-    const animation = Animated.timing(needleRotation, {
-      toValue: cumulativeRotation.current,
-      duration: 350,
-      useNativeDriver: true,
-    });
-
-    animation.start();
-    return () => animation.stop();
-  }, [needleRotation, relativeNeedleHeading]);
-
-  const selectSavedPrayerLocation = async (locationId: string) => {
-    const location = PRAYER_LOCATION_PRESETS.find((item) => item.id === locationId);
-    if (!location) {
-      return;
-    }
-
-    const nextLocation: SavedPrayerLocation = {
-      id: location.id,
-      label: location.label,
-      latitude: location.latitude,
-      longitude: location.longitude,
-    };
-
-    setSavedPrayerLocation(nextLocation);
-    await AsyncStorage.setItem(PRAYER_LOCATION_STORAGE_KEY, JSON.stringify(nextLocation));
-  };
-
-  const clearSavedPrayerLocation = async () => {
-    setSavedPrayerLocation(null);
-    await AsyncStorage.removeItem(PRAYER_LOCATION_STORAGE_KEY);
-  };
+  }, [cameraPermissionStatus, requestCameraPermission]);
 
   const handleCameraPermissionRequest = async () => {
     setIsRequestingCameraPermission(true);
@@ -364,50 +57,8 @@ export default function QiblaScreen() {
     }
   };
 
-  const triggerHaptic = () => {
-    if (process.env.EXPO_OS === 'ios') {
-      void Haptics.selectionAsync();
-    }
-  };
-
-  const handleRecenterCalibration = async () => {
-    setManualHeadingOffset(0);
-    triggerHaptic();
-
-    if (locationPermissionStatus !== 'granted') {
-      return;
-    }
-
-    try {
-      const initialHeading = await Location.getHeadingAsync();
-      const bestHeading =
-        initialHeading.trueHeading >= 0 ? initialHeading.trueHeading : initialHeading.magHeading;
-      setHeading(bestHeading);
-    } catch {
-      // Ignore heading recenter failures; live heading updates continue.
-    }
-  };
-
-  const handleNudgeCalibration = (delta: number) => {
-    setManualHeadingOffset((current) => normalizeOffset(current + delta));
-    triggerHaptic();
-  };
-
-  const needleTransform = {
-    transform: [
-      {
-        rotate: needleRotation.interpolate({
-          inputRange: [0, 360],
-          outputRange: ['0deg', '360deg'],
-        }),
-      },
-    ],
-  };
-
-  const snapPoints = useMemo(() => ['18%', '55%'], []);
-
   return (
-    <View style={styles.screen}>
+    <View style={{ flex: 1 }}>
       <Stack.Screen
         options={{
           title: 'Qibla',
@@ -416,412 +67,39 @@ export default function QiblaScreen() {
         }}
       />
 
-      {activeSubtab === 'compass' ? (
-        <QiblaCompassPage
-          showLiveCamera={showLiveCamera}
-          cameraPermissionStatus={cameraPermissionStatus}
-          canAskCameraPermission={canAskCameraPermission}
-          isRequestingCameraPermission={isRequestingCameraPermission}
-          onRequestCameraPermission={() => {
-            void handleCameraPermissionRequest();
-          }}
-          onOpenCameraSettings={() => {
-            void Linking.openSettings();
-          }}
-          onClose={() => {
-            if (router.canGoBack()) {
-              router.back();
-            }
-          }}
-          onRecenterCalibration={() => {
-            void handleRecenterCalibration();
-          }}
-          onNudgeCalibrationLeft={() => handleNudgeCalibration(-CALIBRATION_STEP_DEGREES)}
-          onNudgeCalibrationRight={() => handleNudgeCalibration(CALIBRATION_STEP_DEGREES)}
-          calibrationOffset={manualHeadingOffset}
-          alignmentDelta={alignmentDelta}
-          isAligned={isAligned}
-          needleTransform={needleTransform}
-        />
-      ) : (
-        <QiblaMapPage
-          originCoords={prayerCoords}
-          originLabel={prayerLocationLabel}
-          locationError={locationError}
-          locationPermissionStatus={locationPermissionStatus}
-          areLocationServicesEnabled={areLocationServicesEnabled}
-          canAskLocationPermission={canAskLocationPermission}
-          isRequestingLocationPermission={isRequestingLocationPermission}
-          onRequestLocationPermission={() =>
-            setLocationPermissionRequestCount((count) => count + 1)
+      <QiblaCompassPage
+        showLiveCamera={showLiveCamera}
+        cameraPermissionStatus={cameraPermissionStatus}
+        canAskCameraPermission={canAskCameraPermission}
+        isRequestingCameraPermission={isRequestingCameraPermission}
+        onRequestCameraPermission={() => {
+          void handleCameraPermissionRequest();
+        }}
+        onOpenCameraSettings={() => {
+          void Linking.openSettings();
+        }}
+        onClose={() => {
+          if (router.canGoBack()) {
+            router.back();
           }
-          onOpenLocationSettings={() => {
-            void Linking.openSettings();
-          }}
-          distanceKm={distanceKm}
-        />
-      )}
-
-      <BottomSheet
-        index={0}
-        snapPoints={snapPoints}
-        enablePanDownToClose={false}
-        backgroundStyle={styles.sheetBackground}
-        handleIndicatorStyle={styles.sheetIndicator}
-      >
-        <BottomSheetScrollView contentContainerStyle={styles.sheetScrollContent}>
-          <View style={styles.segmentWrap}>
-            <Pressable
-              onPress={() => setActiveSubtab('compass')}
-              style={[
-                styles.segmentButton,
-                activeSubtab === 'compass' && styles.segmentButtonActive,
-              ]}
-            >
-              <ThemedText
-                style={[
-                  styles.segmentLabel,
-                  activeSubtab === 'compass' && styles.segmentLabelActive,
-                ]}
-              >
-                Compass
-              </ThemedText>
-            </Pressable>
-            <Pressable
-              onPress={() => setActiveSubtab('map')}
-              style={[styles.segmentButton, activeSubtab === 'map' && styles.segmentButtonActive]}
-            >
-              <ThemedText
-                style={[styles.segmentLabel, activeSubtab === 'map' && styles.segmentLabelActive]}
-              >
-                Map
-              </ThemedText>
-            </Pressable>
-          </View>
-
-          <View style={styles.statsRow}>
-            <View style={styles.statCard}>
-              <ThemedText style={styles.statLabel}>Qibla</ThemedText>
-              <ThemedText style={styles.statValue}>
-                {qiblaBearing === null ? '—' : `${Math.round(qiblaBearing)}°`}
-              </ThemedText>
-            </View>
-            <View style={styles.statCard}>
-              <ThemedText style={styles.statLabel}>Distance</ThemedText>
-              <ThemedText style={styles.statValue}>
-                {distanceKm === null ? '—' : `${distanceKm.toFixed(0)} km`}
-              </ThemedText>
-            </View>
-            <View style={styles.statCard}>
-              <ThemedText style={styles.statLabel}>Accuracy</ThemedText>
-              <ThemedText style={styles.statValueSmall}>{accuracyText}</ThemedText>
-            </View>
-          </View>
-
-          <View style={styles.infoCard}>
-            <ThemedText style={styles.infoTitle}>Alignment</ThemedText>
-            <ThemedText style={styles.infoBody}>
-              {alignmentDelta === null
-                ? 'Align your phone to begin'
-                : isAligned
-                  ? 'Facing Qibla'
-                  : `Turn ${Math.round(alignmentDelta)}° to align with Qibla`}
-            </ThemedText>
-            <ThemedText style={styles.infoSubtle}>
-              {`Manual calibration offset: ${Math.round(manualHeadingOffset)}°`}
-            </ThemedText>
-          </View>
-
-          <View style={styles.infoCard}>
-            <ThemedText style={styles.infoTitle}>Camera</ThemedText>
-            <ThemedText style={styles.infoBody}>
-              {cameraPermissionStatus === 'granted'
-                ? 'Live preview enabled'
-                : 'Camera permission is required for AR-style live background.'}
-            </ThemedText>
-            {cameraPermissionStatus !== 'granted' && canAskCameraPermission ? (
-              <Pressable
-                disabled={isRequestingCameraPermission}
-                onPress={() => {
-                  void handleCameraPermissionRequest();
-                }}
-                style={styles.ctaButton}
-              >
-                <ThemedText style={styles.ctaButtonText}>
-                  {isRequestingCameraPermission ? 'Requesting permission...' : 'Enable camera'}
-                </ThemedText>
-              </Pressable>
-            ) : null}
-            {cameraPermissionStatus !== 'granted' && !canAskCameraPermission ? (
-              <Pressable
-                onPress={() => {
-                  void Linking.openSettings();
-                }}
-                style={styles.secondaryButton}
-              >
-                <ThemedText style={styles.secondaryButtonText}>Open settings</ThemedText>
-              </Pressable>
-            ) : null}
-          </View>
-
-          <View style={styles.infoCard}>
-            <ThemedText style={styles.infoTitle}>Location for Prayer Times</ThemedText>
-            <ThemedText style={styles.infoBody}>
-              {coords
-                ? `Using device location: ${prayerLocationLabel ?? 'Current location'}`
-                : prayerLocationLabel
-                  ? `Using saved location: ${prayerLocationLabel}`
-                  : 'Select a city below to calculate prayer times without location permission.'}
-            </ThemedText>
-
-            {locationError ? (
-              <ThemedText style={styles.errorText}>{locationError}</ThemedText>
-            ) : null}
-
-            {locationPermissionStatus === 'granted' && areLocationServicesEnabled === false ? (
-              <Pressable
-                onPress={() => {
-                  void Linking.openSettings();
-                }}
-                style={styles.ctaButton}
-              >
-                <ThemedText style={styles.ctaButtonText}>Allow location services</ThemedText>
-              </Pressable>
-            ) : null}
-
-            {locationPermissionStatus !== 'granted' && canAskLocationPermission ? (
-              <Pressable
-                disabled={isRequestingLocationPermission}
-                onPress={() => setLocationPermissionRequestCount((count) => count + 1)}
-                style={styles.ctaButton}
-              >
-                <ThemedText style={styles.ctaButtonText}>
-                  {isRequestingLocationPermission ? 'Requesting permission...' : 'Enable location'}
-                </ThemedText>
-              </Pressable>
-            ) : null}
-
-            {locationPermissionStatus !== 'granted' && !canAskLocationPermission ? (
-              <Pressable
-                onPress={() => {
-                  void Linking.openSettings();
-                }}
-                style={styles.secondaryButton}
-              >
-                <ThemedText style={styles.secondaryButtonText}>Open location settings</ThemedText>
-              </Pressable>
-            ) : null}
-
-            <View style={styles.presetWrap}>
-              {PRAYER_LOCATION_PRESETS.map((preset) => (
-                <Pressable
-                  key={preset.id}
-                  onPress={() => {
-                    void selectSavedPrayerLocation(preset.id);
-                  }}
-                  style={[
-                    styles.presetChip,
-                    savedPrayerLocation?.id === preset.id && styles.presetChipActive,
-                  ]}
-                >
-                  <ThemedText
-                    style={[
-                      styles.presetChipText,
-                      savedPrayerLocation?.id === preset.id && styles.presetChipTextActive,
-                    ]}
-                  >
-                    {preset.label}
-                  </ThemedText>
-                </Pressable>
-              ))}
-            </View>
-
-            {savedPrayerLocation ? (
-              <Pressable
-                onPress={() => {
-                  void clearSavedPrayerLocation();
-                }}
-                style={styles.secondaryButton}
-              >
-                <ThemedText style={styles.secondaryButtonText}>Clear saved location</ThemedText>
-              </Pressable>
-            ) : null}
-          </View>
-        </BottomSheetScrollView>
-      </BottomSheet>
+        }}
+        onRecenterCalibration={() => {
+          void recenter();
+        }}
+        onNudgeCalibrationLeft={() => nudgeCalibration(-CALIBRATION_STEP_DEGREES)}
+        onNudgeCalibrationRight={() => nudgeCalibration(CALIBRATION_STEP_DEGREES)}
+        onBeginPrayer={() => {
+          router.push({
+            pathname: '/tradition/islam-session',
+            params: { prayerName: prayerName ?? 'maghrib' },
+          });
+        }}
+        prayerLabel={prayerLabel}
+        calibrationOffset={manualHeadingOffset}
+        alignmentDelta={alignmentOffset}
+        signedOffset={signedOffset ?? 0}
+        alignmentState={alignmentState}
+      />
     </View>
   );
 }
-
-function normalizeDegrees(value: number) {
-  return ((value % 360) + 360) % 360;
-}
-
-function normalizeOffset(value: number) {
-  const normalized = ((((value + 180) % 360) + 360) % 360) - 180;
-  return Math.round(normalized * 10) / 10;
-}
-
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#0b1220',
-  },
-  sheetBackground: {
-    backgroundColor: '#f8fafc',
-    borderRadius: 26,
-  },
-  sheetIndicator: {
-    backgroundColor: '#94a3b8',
-    width: 50,
-  },
-  sheetScrollContent: {
-    paddingHorizontal: 16,
-    paddingBottom: 48,
-    gap: 12,
-  },
-  segmentWrap: {
-    flexDirection: 'row',
-    backgroundColor: '#e2e8f0',
-    borderRadius: 999,
-    padding: 4,
-    gap: 6,
-  },
-  segmentButton: {
-    flex: 1,
-    borderRadius: 999,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 8,
-  },
-  segmentButtonActive: {
-    backgroundColor: '#ffffff',
-  },
-  segmentLabel: {
-    color: '#334155',
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: '700',
-  },
-  segmentLabelActive: {
-    color: '#0f172a',
-  },
-  statsRow: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  statCard: {
-    flex: 1,
-    borderRadius: 16,
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-    padding: 10,
-    gap: 3,
-  },
-  statLabel: {
-    color: '#64748b',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
-  statValue: {
-    color: '#0f172a',
-    fontSize: 18,
-    lineHeight: 22,
-    fontWeight: '800',
-    fontVariant: ['tabular-nums'],
-  },
-  statValueSmall: {
-    color: '#0f172a',
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: '700',
-  },
-  infoCard: {
-    borderRadius: 18,
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-    padding: 12,
-    gap: 8,
-  },
-  infoTitle: {
-    color: '#0f172a',
-    fontSize: 15,
-    lineHeight: 20,
-    fontWeight: '800',
-  },
-  infoBody: {
-    color: '#334155',
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: '600',
-  },
-  infoSubtle: {
-    color: '#64748b',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '600',
-    fontVariant: ['tabular-nums'],
-  },
-  ctaButton: {
-    alignSelf: 'flex-start',
-    borderRadius: 999,
-    backgroundColor: '#111827',
-    paddingHorizontal: 12,
-    paddingVertical: 7,
-  },
-  ctaButtonText: {
-    color: '#ffffff',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
-  secondaryButton: {
-    alignSelf: 'flex-start',
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: '#cbd5e1',
-    paddingHorizontal: 12,
-    paddingVertical: 7,
-  },
-  secondaryButtonText: {
-    color: '#0f172a',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
-  presetWrap: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-  },
-  presetChip: {
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: '#cbd5e1',
-    backgroundColor: '#f8fafc',
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-  },
-  presetChipActive: {
-    borderColor: 'rgba(22,163,74,0.5)',
-    backgroundColor: '#dcfce7',
-  },
-  presetChipText: {
-    color: '#1e293b',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
-  presetChipTextActive: {
-    color: '#166534',
-  },
-  errorText: {
-    color: '#b91c1c',
-    fontSize: 12,
-    lineHeight: 17,
-    fontWeight: '600',
-  },
-});

--- a/components/qibla/qibla-compass-page.tsx
+++ b/components/qibla/qibla-compass-page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ActivityIndicator, Animated, Pressable, StyleSheet, View, ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import type { QiblaAlignmentState } from '@/hooks/use-qibla-alignment';
 import { ThemedText } from '@/components/themed-text';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 
@@ -23,14 +24,12 @@ type QiblaCompassPageProps = {
   onRecenterCalibration: () => void;
   onNudgeCalibrationLeft: () => void;
   onNudgeCalibrationRight: () => void;
+  onBeginPrayer: () => void;
+  prayerLabel: string;
   calibrationOffset: number;
   alignmentDelta: number | null;
-  isAligned: boolean;
-  needleTransform: {
-    transform: {
-      rotate: Animated.AnimatedInterpolation<string | number>;
-    }[];
-  };
+  signedOffset: number;
+  alignmentState: QiblaAlignmentState;
 };
 
 export function QiblaCompassPage({
@@ -44,10 +43,12 @@ export function QiblaCompassPage({
   onRecenterCalibration,
   onNudgeCalibrationLeft,
   onNudgeCalibrationRight,
+  onBeginPrayer,
+  prayerLabel,
   calibrationOffset,
   alignmentDelta,
-  isAligned,
-  needleTransform,
+  signedOffset,
+  alignmentState,
 }: QiblaCompassPageProps) {
   const insets = useSafeAreaInsets();
   const [safeCameraView, setSafeCameraView] = React.useState<CameraViewComponentType | null>(null);
@@ -58,17 +59,14 @@ export function QiblaCompassPage({
 
     import('expo-camera')
       .then((cameraModule) => {
-        if (!isMounted) {
-          return;
-        }
+        if (!isMounted) return;
         if (typeof cameraModule.CameraView === 'function') {
-          setSafeCameraView(() => cameraModule.CameraView);
+          setSafeCameraView(cameraModule.CameraView as CameraViewComponentType);
         } else {
           setSafeCameraView(null);
         }
       })
       .catch(() => {
-        console.warn('expo-camera could not be loaded');
         if (isMounted) {
           setSafeCameraView(null);
         }
@@ -78,6 +76,10 @@ export function QiblaCompassPage({
       isMounted = false;
     };
   }, []);
+
+  const arrowAngle = Math.max(-90, Math.min(90, signedOffset));
+  const isAligned = alignmentState === 'aligned';
+  const isNearAligned = alignmentState === 'nearAligned';
 
   return (
     <View style={styles.container}>
@@ -97,36 +99,62 @@ export function QiblaCompassPage({
         <View style={[StyleSheet.absoluteFill, styles.fallbackBackground]} />
       )}
 
-      <View pointerEvents="none" style={[StyleSheet.absoluteFill, styles.sceneScrim]} />
+      <View pointerEvents="none" style={styles.sceneScrim} />
 
       <View pointerEvents="box-none" style={[styles.topControls, { top: insets.top + 12 }]}>
-        <Pressable onPress={onClose} style={styles.iconButton}>
+        <Pressable
+          onPress={onClose}
+          style={styles.iconButton}
+          accessibilityLabel="Close Qibla alignment"
+          accessibilityRole="button"
+        >
           <IconSymbol name="close" size={20} color="#ffffff" />
         </Pressable>
 
-        <Pressable onPress={onRecenterCalibration} style={styles.iconButton}>
+        <Pressable
+          onPress={onRecenterCalibration}
+          style={styles.iconButton}
+          accessibilityLabel="Recenter Qibla heading"
+          accessibilityRole="button"
+        >
           <IconSymbol name="arrow.clockwise" size={20} color="#ffffff" />
         </Pressable>
       </View>
 
       <View pointerEvents="none" style={styles.centerZone}>
-        <Animated.View style={[styles.reticleWrap, needleTransform]}>
-          <View style={styles.reticleRingOuter} />
-          <View style={styles.reticleRingInner} />
-          <View style={styles.kaabaBadge}>
-            <IconSymbol name="kaaba" size={22} color="#161616" />
-          </View>
-        </Animated.View>
+        <View style={[styles.reticleRingOuter, isAligned && styles.reticleRingAligned]} />
+        <View
+          style={[styles.reticleRingInner, (isNearAligned || isAligned) && styles.reticleRingNear]}
+        />
 
-        <View style={styles.dashedGuide} />
-        <View style={styles.directionArrow} />
+        <View style={[styles.kaabaBadge, isAligned && styles.kaabaBadgeAligned]}>
+          <IconSymbol name="kaaba" size={28} color={isAligned ? '#362200' : '#161616'} />
+        </View>
+
+        <View style={styles.guideLine} />
+
+        <Animated.View
+          style={[
+            styles.directionArrow,
+            {
+              transform: [{ rotate: `${arrowAngle}deg` }],
+              opacity: isAligned ? 0.2 : isNearAligned ? 0.45 : 0.95,
+            },
+          ]}
+        />
+      </View>
+
+      <View pointerEvents="none" style={[styles.carpetWrap, isAligned && styles.carpetWrapAligned]}>
+        <View style={styles.carpetOuter}>
+          <View style={styles.carpetInner} />
+        </View>
       </View>
 
       {!showLiveCamera ? (
         <View style={[styles.permissionNoticeWrap, { top: insets.top + 76 }]}>
           <ThemedText style={styles.permissionNoticeTitle}>Camera unavailable</ThemedText>
           <ThemedText style={styles.permissionNoticeBody}>
-            Enable camera access for live Qibla view.
+            Enable camera access for the immersive Qibla alignment scene.
           </ThemedText>
           {cameraPermissionStatus !== 'granted' && canAskCameraPermission ? (
             <Pressable
@@ -147,55 +175,58 @@ export function QiblaCompassPage({
         </View>
       ) : null}
 
-      <View
-        pointerEvents="box-none"
-        style={[styles.bottomControls, { bottom: Math.max(insets.bottom + 136, 148) }]}
-      >
-        <Pressable onPress={onNudgeCalibrationLeft} style={styles.arrowButton}>
-          <IconSymbol name="chevron.left" size={24} color="#ffffff" />
-        </Pressable>
+      <View style={[styles.statusCard, { bottom: insets.bottom + 24 }]}>
+        <ThemedText style={styles.statusTitle}>
+          {isAligned ? 'Qibla Aligned' : isNearAligned ? 'Almost aligned' : 'Facing the Qibla…'}
+        </ThemedText>
+        <ThemedText style={styles.statusSubtitle}>
+          {isAligned
+            ? prayerLabel
+            : alignmentDelta === null
+              ? 'Finding direction…'
+              : `Rotate ${Math.round(alignmentDelta)}° to align`}
+        </ThemedText>
 
-        <View pointerEvents="none" style={styles.alignmentPill}>
-          <ThemedText style={styles.alignmentPrimary}>
-            {isAligned
-              ? 'Aligned'
-              : alignmentDelta === null
-                ? 'Aligning...'
-                : `${Math.round(alignmentDelta)}°`}
-          </ThemedText>
-          <ThemedText
-            style={styles.alignmentSecondary}
-          >{`Offset ${Math.round(calibrationOffset)}°`}</ThemedText>
-        </View>
-
-        <Pressable onPress={onNudgeCalibrationRight} style={styles.arrowButton}>
-          <IconSymbol name="chevron.right" size={24} color="#ffffff" />
-        </Pressable>
+        {isAligned ? (
+          <Pressable
+            onPress={onBeginPrayer}
+            style={styles.beginButton}
+            accessibilityRole="button"
+            accessibilityLabel={`Begin ${prayerLabel}`}
+          >
+            <ThemedText style={styles.beginButtonText}>Begin Prayer</ThemedText>
+          </Pressable>
+        ) : (
+          <View style={styles.calibrationRow}>
+            <Pressable onPress={onNudgeCalibrationLeft} style={styles.arrowButton}>
+              <IconSymbol name="chevron.left" size={20} color="#ffffff" />
+            </Pressable>
+            <ThemedText
+              style={styles.calibrationText}
+            >{`Offset ${Math.round(calibrationOffset)}°`}</ThemedText>
+            <Pressable onPress={onNudgeCalibrationRight} style={styles.arrowButton}>
+              <IconSymbol name="chevron.right" size={20} color="#ffffff" />
+            </Pressable>
+          </View>
+        )}
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#0f172a',
-  },
-  fallbackBackground: {
-    backgroundColor: '#0b101f',
-  },
+  container: { flex: 1, backgroundColor: '#080e15' },
+  fallbackBackground: { backgroundColor: '#070f18' },
   cameraLoadingState: {
     alignItems: 'center',
     justifyContent: 'center',
     gap: 12,
-    backgroundColor: '#0b101f',
+    backgroundColor: '#070f18',
   },
-  cameraLoadingText: {
-    color: '#f8fafc',
-    fontSize: 14,
-  },
+  cameraLoadingText: { color: '#f8fafc', fontSize: 14 },
   sceneScrim: {
-    backgroundColor: 'rgba(0, 0, 0, 0.22)',
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.34)',
   },
   topControls: {
     position: 'absolute',
@@ -211,7 +242,7 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     backgroundColor: 'rgba(0,0,0,0.45)',
     borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.26)',
+    borderColor: 'rgba(255,255,255,0.22)',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -219,59 +250,93 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 3,
-  },
-  reticleWrap: {
-    width: 188,
-    height: 188,
-    borderRadius: 94,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 14,
+    paddingBottom: 110,
   },
   reticleRingOuter: {
     position: 'absolute',
-    width: 188,
-    height: 188,
-    borderRadius: 94,
-    borderWidth: 4,
-    borderColor: 'rgba(255,255,255,0.9)',
+    width: 196,
+    height: 196,
+    borderRadius: 98,
+    borderWidth: 3,
+    borderColor: 'rgba(255,255,255,0.65)',
   },
   reticleRingInner: {
     position: 'absolute',
     width: 122,
     height: 122,
     borderRadius: 61,
-    borderWidth: 3,
-    borderColor: 'rgba(255,255,255,0.9)',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.5)',
+  },
+  reticleRingNear: {
+    borderColor: 'rgba(255,221,143,0.88)',
+  },
+  reticleRingAligned: {
+    borderColor: 'rgba(255,223,120,0.96)',
+    shadowColor: '#F7C95F',
+    shadowOpacity: 0.56,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 0 },
   },
   kaabaBadge: {
-    width: 52,
-    height: 52,
-    borderRadius: 16,
-    backgroundColor: '#fff3bf',
-    borderWidth: 1,
-    borderColor: 'rgba(0,0,0,0.25)',
+    width: 68,
+    height: 68,
+    borderRadius: 20,
+    backgroundColor: '#fff4ca',
     alignItems: 'center',
     justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.2)',
   },
-  dashedGuide: {
-    width: 2,
-    height: 210,
-    borderStyle: 'dashed',
+  kaabaBadgeAligned: {
+    backgroundColor: '#ffe7a8',
+    transform: [{ scale: 1.04 }],
+  },
+  guideLine: {
+    position: 'absolute',
+    top: '58%',
+    height: 180,
     borderLeftWidth: 2,
-    borderLeftColor: 'rgba(255,255,255,0.88)',
+    borderLeftColor: 'rgba(255,255,255,0.8)',
+    borderStyle: 'dashed',
   },
   directionArrow: {
-    marginTop: 6,
+    marginTop: 220,
     width: 0,
     height: 0,
-    borderLeftWidth: 16,
-    borderRightWidth: 16,
-    borderBottomWidth: 26,
+    borderLeftWidth: 15,
+    borderRightWidth: 15,
+    borderBottomWidth: 28,
     borderLeftColor: 'transparent',
     borderRightColor: 'transparent',
-    borderBottomColor: 'rgba(255,255,255,0.95)',
+    borderBottomColor: 'rgba(255,255,255,0.96)',
+  },
+  carpetWrap: {
+    position: 'absolute',
+    left: '18%',
+    right: '18%',
+    bottom: 150,
+    alignItems: 'center',
+    transform: [{ perspective: 280 }, { rotateX: '56deg' }],
+  },
+  carpetWrapAligned: {
+    opacity: 0.95,
+  },
+  carpetOuter: {
+    width: '100%',
+    height: 126,
+    borderRadius: 8,
+    borderWidth: 3,
+    borderColor: 'rgba(255,239,197,0.92)',
+    backgroundColor: 'rgba(12,12,14,0.84)',
+    padding: 10,
+  },
+  carpetInner: {
+    flex: 1,
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: 'rgba(237,188,84,0.85)',
+    backgroundColor: 'rgba(8,8,10,0.88)',
   },
   permissionNoticeWrap: {
     position: 'absolute',
@@ -280,94 +345,85 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     padding: 14,
     gap: 8,
-    backgroundColor: 'rgba(2, 6, 23, 0.7)',
+    backgroundColor: 'rgba(2, 6, 23, 0.82)',
     borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.25)',
-    zIndex: 1,
+    borderColor: 'rgba(255,255,255,0.28)',
   },
-  permissionNoticeTitle: {
-    color: '#ffffff',
-    fontSize: 16,
-    lineHeight: 20,
-    fontWeight: '800',
-  },
-  permissionNoticeBody: {
-    color: 'rgba(255,255,255,0.84)',
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: '600',
-  },
+  permissionNoticeTitle: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  permissionNoticeBody: { color: 'rgba(255,255,255,0.84)', fontSize: 13, lineHeight: 18 },
   permissionButton: {
     alignSelf: 'flex-start',
     borderRadius: 999,
     paddingHorizontal: 12,
-    paddingVertical: 7,
-    backgroundColor: '#ffffff',
+    paddingVertical: 8,
+    backgroundColor: '#fff',
   },
-  permissionButtonText: {
-    color: '#111827',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
+  permissionButtonText: { color: '#111827', fontSize: 12, fontWeight: '700' },
   permissionSettingsButton: {
     alignSelf: 'flex-start',
     borderRadius: 999,
     paddingHorizontal: 12,
-    paddingVertical: 7,
+    paddingVertical: 8,
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.5)',
   },
-  permissionSettingsButtonText: {
-    color: '#ffffff',
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: '700',
-  },
-  bottomControls: {
+  permissionSettingsButtonText: { color: '#fff', fontSize: 12, fontWeight: '700' },
+  statusCard: {
     position: 'absolute',
     left: 16,
     right: 16,
+    borderRadius: 24,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    backgroundColor: 'rgba(8,16,24,0.74)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,224,168,0.35)',
+    gap: 10,
+  },
+  statusTitle: {
+    color: '#fff5d6',
+    fontSize: 22,
+    textAlign: 'center',
+    fontWeight: '500',
+  },
+  statusSubtitle: {
+    color: 'rgba(255,240,204,0.84)',
+    textAlign: 'center',
+    fontSize: 14,
+  },
+  beginButton: {
+    marginTop: 2,
+    height: 52,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(247,203,103,0.66)',
+    backgroundColor: 'rgba(212,175,55,0.24)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  beginButtonText: {
+    color: '#fff0c0',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  calibrationRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    zIndex: 6,
-    gap: 10,
   },
   arrowButton: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'rgba(0,0,0,0.45)',
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.24)',
   },
-  alignmentPill: {
-    flex: 1,
-    borderRadius: 999,
-    backgroundColor: 'rgba(2,6,23,0.66)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.26)',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 2,
-  },
-  alignmentPrimary: {
-    color: '#ffffff',
-    fontSize: 14,
-    lineHeight: 18,
-    fontWeight: '800',
-    fontVariant: ['tabular-nums'],
-  },
-  alignmentSecondary: {
-    color: 'rgba(255,255,255,0.82)',
-    fontSize: 11,
-    lineHeight: 14,
-    fontWeight: '600',
+  calibrationText: {
+    color: 'rgba(255,240,206,0.86)',
+    fontSize: 13,
     fontVariant: ['tabular-nums'],
   },
 });

--- a/hooks/use-qibla-alignment.ts
+++ b/hooks/use-qibla-alignment.ts
@@ -1,0 +1,233 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Haptics from 'expo-haptics';
+import * as Location from 'expo-location';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { PRAYER_LOCATION_STORAGE_KEY, type SavedPrayerLocation } from '@/lib/islam-prayer-location';
+import { getQiblaBearing } from '@/lib/qibla';
+
+export type QiblaAlignmentState = 'notAligned' | 'nearAligned' | 'aligned';
+
+const ALIGNED_ENTER = 5;
+const ALIGNED_EXIT = 7;
+const NEAR_ENTER = 15;
+const NEAR_EXIT = 17;
+const HEADING_SMOOTHING_ALPHA = 0.18;
+
+function normalizeDegrees(value: number) {
+  return ((value % 360) + 360) % 360;
+}
+
+function shortestSignedAngle(from: number, to: number) {
+  return ((((to - from) % 360) + 540) % 360) - 180;
+}
+
+function getAlignmentState(offset: number, previous: QiblaAlignmentState): QiblaAlignmentState {
+  if (previous === 'aligned') {
+    if (offset <= ALIGNED_EXIT) return 'aligned';
+    if (offset <= NEAR_ENTER) return 'nearAligned';
+    return 'notAligned';
+  }
+
+  if (previous === 'nearAligned') {
+    if (offset < ALIGNED_ENTER) return 'aligned';
+    if (offset <= NEAR_EXIT) return 'nearAligned';
+    return 'notAligned';
+  }
+
+  if (offset < ALIGNED_ENTER) return 'aligned';
+  if (offset <= NEAR_ENTER) return 'nearAligned';
+  return 'notAligned';
+}
+
+export function useQiblaAlignment() {
+  const [coords, setCoords] = useState<Location.LocationObjectCoords | null>(null);
+  const [locationPermissionStatus, setLocationPermissionStatus] =
+    useState<Location.PermissionStatus | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [savedPrayerLocation, setSavedPrayerLocation] = useState<SavedPrayerLocation | null>(null);
+  const [rawHeading, setRawHeading] = useState(0);
+  const [smoothedHeading, setSmoothedHeading] = useState(0);
+  const [manualHeadingOffset, setManualHeadingOffset] = useState(0);
+  const [alignmentState, setAlignmentState] = useState<QiblaAlignmentState>('notAligned');
+
+  const alignmentStateRef = useRef<QiblaAlignmentState>('notAligned');
+  const hasAlignedHapticRef = useRef(false);
+
+  const prayerCoords = useMemo(() => {
+    if (coords) {
+      return coords;
+    }
+
+    if (savedPrayerLocation) {
+      return {
+        latitude: savedPrayerLocation.latitude,
+        longitude: savedPrayerLocation.longitude,
+      };
+    }
+
+    return null;
+  }, [coords, savedPrayerLocation]);
+
+  const qiblaBearing = useMemo(() => {
+    if (!prayerCoords) return null;
+    return getQiblaBearing(prayerCoords.latitude, prayerCoords.longitude);
+  }, [prayerCoords]);
+
+  const effectiveHeading = useMemo(
+    () => normalizeDegrees(smoothedHeading + manualHeadingOffset),
+    [manualHeadingOffset, smoothedHeading],
+  );
+
+  const signedOffset = useMemo(() => {
+    if (qiblaBearing === null) return null;
+    return shortestSignedAngle(effectiveHeading, qiblaBearing);
+  }, [effectiveHeading, qiblaBearing]);
+
+  const alignmentOffset = useMemo(() => {
+    if (signedOffset === null) return null;
+    return Math.abs(signedOffset);
+  }, [signedOffset]);
+
+  useEffect(() => {
+    if (alignmentOffset === null) {
+      setAlignmentState('notAligned');
+      alignmentStateRef.current = 'notAligned';
+      return;
+    }
+
+    const nextState = getAlignmentState(alignmentOffset, alignmentStateRef.current);
+    alignmentStateRef.current = nextState;
+    setAlignmentState(nextState);
+  }, [alignmentOffset]);
+
+  useEffect(() => {
+    if (alignmentState === 'aligned' && !hasAlignedHapticRef.current) {
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      hasAlignedHapticRef.current = true;
+      return;
+    }
+
+    if (alignmentState !== 'aligned') {
+      hasAlignedHapticRef.current = false;
+    }
+  }, [alignmentState]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadSavedPrayerLocation = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(PRAYER_LOCATION_STORAGE_KEY);
+        if (!stored || !mounted) return;
+
+        const parsed = JSON.parse(stored) as Partial<SavedPrayerLocation>;
+        if (
+          typeof parsed.id !== 'string' ||
+          typeof parsed.label !== 'string' ||
+          typeof parsed.latitude !== 'number' ||
+          typeof parsed.longitude !== 'number'
+        ) {
+          return;
+        }
+
+        setSavedPrayerLocation({
+          id: parsed.id,
+          label: parsed.label,
+          latitude: parsed.latitude,
+          longitude: parsed.longitude,
+        });
+      } catch {
+        // ignore invalid cache
+      }
+    };
+
+    void loadSavedPrayerLocation();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    let headingSubscription: Location.LocationSubscription | null = null;
+
+    const setup = async () => {
+      try {
+        const permission = await Location.requestForegroundPermissionsAsync();
+        if (!mounted) return;
+
+        setLocationPermissionStatus(permission.status);
+        if (permission.status !== 'granted') {
+          setLocationError('Location access helps improve Qibla precision.');
+          return;
+        }
+
+        const current = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        });
+        if (!mounted) return;
+        setCoords(current.coords);
+
+        const heading = await Location.getHeadingAsync();
+        const initialHeading = heading.trueHeading >= 0 ? heading.trueHeading : heading.magHeading;
+
+        if (mounted) {
+          setRawHeading(initialHeading);
+          setSmoothedHeading(initialHeading);
+        }
+
+        headingSubscription = await Location.watchHeadingAsync((nextHeading) => {
+          if (!mounted) return;
+
+          const liveHeading =
+            nextHeading.trueHeading >= 0 ? nextHeading.trueHeading : nextHeading.magHeading;
+
+          setRawHeading(liveHeading);
+          setSmoothedHeading((prev) => {
+            const delta = shortestSignedAngle(prev, liveHeading);
+            return normalizeDegrees(prev + delta * HEADING_SMOOTHING_ALPHA);
+          });
+        });
+      } catch {
+        if (mounted) {
+          setLocationError('Compass data is unavailable on this device.');
+        }
+      }
+    };
+
+    void setup();
+
+    return () => {
+      mounted = false;
+      headingSubscription?.remove();
+    };
+  }, []);
+
+  const recenter = useCallback(async () => {
+    setManualHeadingOffset(0);
+    const heading = await Location.getHeadingAsync();
+    const nextHeading = heading.trueHeading >= 0 ? heading.trueHeading : heading.magHeading;
+    setRawHeading(nextHeading);
+    setSmoothedHeading(nextHeading);
+  }, []);
+
+  const nudgeCalibration = useCallback((delta: number) => {
+    setManualHeadingOffset((current) => current + delta);
+  }, []);
+
+  return {
+    qiblaBearing,
+    alignmentOffset,
+    signedOffset,
+    alignmentState,
+    isAligned: alignmentState === 'aligned',
+    manualHeadingOffset,
+    locationError,
+    locationPermissionStatus,
+    rawHeading,
+    recenter,
+    nudgeCalibration,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a stable, premium-feeling Qibla alignment experience that uses the device camera, heading data, and subtle overlays to guide users into prayer while preserving the existing Islamic flow.
- Centralize sensor, bearing math and alignment-state logic in a reusable hook to avoid scattered compass logic and enable Phase 2 polish later.

### Description
- Added a new hook `useQiblaAlignment` that computes Qibla bearing, normalizes signed/absolute offsets, applies heading smoothing, enforces hysteresis thresholds for `notAligned`/`nearAligned`/`aligned`, and triggers a one-shot success haptic when entering aligned state (file: `hooks/use-qibla-alignment.ts`).
- Reworked the compass page into an immersive camera-backed alignment screen with overlays: Kaaba ring/target, directional arrow, prayer carpet, permission fallback UI, accessible controls, and a gated `Begin Prayer` CTA that appears only in the aligned state (modified: `components/qibla/qibla-compass-page.tsx`).
- Wired the alignment screen into app navigation and passed prayer context to the session start flow so tapping `Begin Prayer` routes into the existing Islamic session screen with params (modified: `app/(tabs)/qibla.tsx`).
- Phase 2 polish items included: heading smoothing constant, hysteresis thresholds for stable state transitions, visual state emphasis (ring glow / arrow opacity / carpet subtlety), and accessibility labels for important controls; no new npm packages were added.

### Testing
- Ran `npm run lint` and auto-formatting (Prettier) which completed successfully.
- Ran `npx tsc --noEmit` which surfaced pre-existing repository TypeScript errors unrelated to these changes (type-check did not fully pass due to those unrelated issues).
- Attempted to run the web dev server (`npm run web`) and capture a screenshot via automated browser tooling, but the Playwright capture timed out in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16aa9693883239bc8a71ecbdcb946)