### PR TITLE
feat(islam): add completion flow, session logging, and notification handler

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { TraditionProvider, useTradition } from '@/hooks/use-tradition';
 import { UserProvider } from '@/hooks/use-user';
+import { configureNotifications } from '@/lib/notifications';
 
 export const unstable_settings = {
   initialRouteName: 'onboarding/index',
@@ -50,10 +51,7 @@ function RootLayoutNav() {
           name="tradition/buddhist-prayer"
           options={{ presentation: 'fullScreenModal' }}
         />
-        <Stack.Screen
-          name="tradition/christian"
-          options={{ presentation: 'fullScreenModal' }}
-        />
+        <Stack.Screen name="tradition/christian" options={{ presentation: 'fullScreenModal' }} />
         <Stack.Screen
           name="tradition/christian-preparation"
           options={{ presentation: 'fullScreenModal' }}
@@ -74,6 +72,10 @@ function RootLayoutNav() {
           name="tradition/islam-preparation"
           options={{ presentation: 'fullScreenModal' }}
         />
+        <Stack.Screen
+          name="tradition/islam-completion"
+          options={{ presentation: 'fullScreenModal' }}
+        />
         <Stack.Screen name="tradition/general" options={{ presentation: 'modal' }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
@@ -83,6 +85,10 @@ function RootLayoutNav() {
 }
 
 export default function RootLayout() {
+  useEffect(() => {
+    configureNotifications();
+  }, []);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <UserProvider>

--- a/app/tradition/islam-completion.tsx
+++ b/app/tradition/islam-completion.tsx
@@ -1,0 +1,190 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { formatDuration } from '@/lib/chant-helpers';
+import { recordPrayerCompletion } from '@/lib/focus-gate';
+
+type CompletionParams = {
+  prayerName?: string | string[];
+  durationSeconds?: string | string[];
+};
+
+function toTitleCase(value: string): string {
+  return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export default function IslamCompletionScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<CompletionParams>();
+  const completionRecordedRef = useRef(false);
+
+  useEffect(() => {
+    if (completionRecordedRef.current) {
+      return;
+    }
+
+    completionRecordedRef.current = true;
+    void recordPrayerCompletion();
+  }, []);
+
+  const prayerNameParam = Array.isArray(params.prayerName)
+    ? params.prayerName[0]
+    : params.prayerName;
+  const durationParam = Array.isArray(params.durationSeconds)
+    ? params.durationSeconds[0]
+    : params.durationSeconds;
+  const durationSeconds = Number.isFinite(Number(durationParam)) ? Number(durationParam) : 0;
+  const prayerLabel = prayerNameParam ? `${toTitleCase(prayerNameParam)} Prayer` : 'Prayer';
+
+  const completionMessage = useMemo(
+    () => `May your ${prayerLabel.toLowerCase()} bring you peace and steadfastness.`,
+    [prayerLabel],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <LinearGradient
+        colors={['#04150F', '#06231A', '#0C3225']}
+        style={StyleSheet.absoluteFillObject}
+      />
+
+      <View style={styles.content}>
+        <View style={styles.iconCircle}>
+          <IconSymbol name="checkmark.circle.fill" size={44} color="#F4C86B" />
+        </View>
+
+        <ThemedText style={styles.eyebrow}>Session Complete</ThemedText>
+        <ThemedText style={styles.title}>{prayerLabel}</ThemedText>
+        <ThemedText style={styles.subtitle}>{completionMessage}</ThemedText>
+
+        <View style={styles.statCard}>
+          <ThemedText style={styles.statValue}>{formatDuration(durationSeconds)}</ThemedText>
+          <ThemedText style={styles.statLabel}>Duration</ThemedText>
+        </View>
+
+        <View style={styles.actions}>
+          <Pressable
+            onPress={() =>
+              router.replace({
+                pathname: '/tradition/islam-preparation',
+                params: { prayerName: prayerNameParam },
+              })
+            }
+            style={styles.primaryButton}
+          >
+            <ThemedText style={styles.primaryButtonText}>Pray Again</ThemedText>
+          </Pressable>
+
+          <Pressable
+            onPress={() => router.replace('/(tabs)/prayers')}
+            style={styles.secondaryButton}
+          >
+            <ThemedText style={styles.secondaryButtonText}>Return to Prayer List</ThemedText>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#04150F',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 18,
+  },
+  iconCircle: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(244,200,107,0.25)',
+  },
+  eyebrow: {
+    color: '#F4C86B',
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#FFF6DF',
+    fontSize: 34,
+    lineHeight: 40,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: 'rgba(247,233,192,0.82)',
+    fontSize: 16,
+    lineHeight: 25,
+    textAlign: 'center',
+  },
+  statCard: {
+    width: '100%',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 18,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(244,200,107,0.18)',
+  },
+  statValue: {
+    color: '#FFF6DF',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  statLabel: {
+    color: 'rgba(247,233,192,0.65)',
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  actions: {
+    width: '100%',
+    gap: 10,
+  },
+  primaryButton: {
+    minHeight: 52,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F4C86B',
+  },
+  primaryButtonText: {
+    color: '#2F1A10',
+    fontSize: 15,
+    fontWeight: '800',
+  },
+  secondaryButton: {
+    minHeight: 52,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(244,200,107,0.24)',
+  },
+  secondaryButtonText: {
+    color: '#FFF6DF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/app/tradition/islam-session.tsx
+++ b/app/tradition/islam-session.tsx
@@ -11,6 +11,7 @@ import { PrayerSessionControls } from '@/components/islam/session/prayer-session
 import { PrayerSessionTimer } from '@/components/islam/session/prayer-session-timer';
 import { ThemedText } from '@/components/themed-text';
 import { usePrayerSessionVisibilityControls } from '@/hooks/use-prayer-session-visibility-controls';
+import { addSessionLogEntry } from '@/lib/session-log';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,6 +53,7 @@ export default function IslamPrayerSessionScreen() {
   const masterFade = useRef(new Animated.Value(0)).current;
   const helperFade = useRef(new Animated.Value(0)).current;
   const helperTranslate = useRef(new Animated.Value(8)).current;
+  const sessionStartedAtRef = useRef(Date.now());
 
   useEffect(() => {
     // Fade in the whole scene.
@@ -83,9 +85,27 @@ export default function IslamPrayerSessionScreen() {
 
   // ---- Handlers ----
   const handleEndSession = () => {
-    // TODO: If a proper session-tracking service is introduced, call its
-    // completion handler here before navigating away.
-    router.back();
+    const completedAtMs = Date.now();
+    const durationSeconds = Math.max(
+      0,
+      Math.floor((completedAtMs - sessionStartedAtRef.current) / 1000),
+    );
+
+    void addSessionLogEntry({
+      tradition: 'islam',
+      prayerName: prayerName && prayerName !== '' ? prayerName : undefined,
+      startedAtMs: sessionStartedAtRef.current,
+      completedAtMs,
+      durationSeconds,
+    });
+
+    router.replace({
+      pathname: '/tradition/islam-completion',
+      params: {
+        prayerName: prayerName && prayerName !== '' ? prayerName : undefined,
+        durationSeconds: String(durationSeconds),
+      },
+    });
   };
 
   const handleEmergencyExit = () => {

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,20 @@
+import * as Notifications from 'expo-notifications';
+
+let notificationHandlerConfigured = false;
+
+export function configureNotifications() {
+  if (notificationHandlerConfigured) {
+    return;
+  }
+
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldPlaySound: true,
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldSetBadge: false,
+    }),
+  });
+
+  notificationHandlerConfigured = true;
+}

--- a/lib/session-log.ts
+++ b/lib/session-log.ts
@@ -1,0 +1,67 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { PrayerName } from '@/lib/prayer-times';
+
+const SESSION_LOG_STORAGE_KEY = '@oremus/session-log-v1';
+
+export type SessionLogTradition = 'islam' | 'christianity' | 'buddhism' | 'general';
+
+export type SessionLogEntry = {
+  id: string;
+  tradition: SessionLogTradition;
+  prayerName?: PrayerName;
+  startedAtMs: number;
+  completedAtMs: number;
+  durationSeconds: number;
+};
+
+type SessionLogInput = Omit<SessionLogEntry, 'id'>;
+
+function normalizeEntry(entry: SessionLogInput): SessionLogEntry {
+  const safeDuration = Number.isFinite(entry.durationSeconds)
+    ? Math.max(0, Math.floor(entry.durationSeconds))
+    : 0;
+
+  return {
+    ...entry,
+    durationSeconds: safeDuration,
+    id: `${entry.tradition}:${entry.prayerName ?? 'session'}:${entry.completedAtMs}`,
+  };
+}
+
+function parseEntries(raw: string | null): SessionLogEntry[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as SessionLogEntry[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+let sessionLogQueue: Promise<unknown> = Promise.resolve();
+
+export async function getSessionLogEntries(): Promise<SessionLogEntry[]> {
+  const raw = await AsyncStorage.getItem(SESSION_LOG_STORAGE_KEY);
+  return parseEntries(raw);
+}
+
+export async function addSessionLogEntry(entry: SessionLogInput): Promise<SessionLogEntry[]> {
+  const normalized = normalizeEntry(entry);
+
+  const result = (sessionLogQueue = sessionLogQueue.then(async () => {
+    const existing = await getSessionLogEntries();
+    const next = [normalized, ...existing].slice(0, 250);
+    await AsyncStorage.setItem(SESSION_LOG_STORAGE_KEY, JSON.stringify(next));
+    return next;
+  })) as Promise<SessionLogEntry[]>;
+
+  return result;
+}


### PR DESCRIPTION
### Motivation
- Provide a proper session-completion UX for the Islamic tradition and close the gap where the session end action did not mark a session complete or record focus-gate state. 
- Add lightweight session observability so completed sessions can be stored and inspected for analytics or user features. 
- Ensure scheduled prayer reminders actually present as notifications by configuring a notification handler at app startup.

### Description
- Added a new completion route at `app/tradition/islam-completion.tsx` that records the focus-gate completion (`recordPrayerCompletion`) on first render and displays session summary including duration. 
- Implemented a session tracking service `lib/session-log.ts` that persists `SessionLogEntry` objects to `AsyncStorage` with normalized entries, a write queue (`sessionLogQueue`) and a capped retention of 250 entries. 
- Hardened notification behavior with `lib/notifications.ts` that calls `Notifications.setNotificationHandler(...)` and wired `configureNotifications()` into the root layout (`app/_layout.tsx`) so the handler is configured on app startup. 
- Updated the Islam session end flow in `app/tradition/islam-session.tsx` to record a session entry via `addSessionLogEntry(...)` and navigate to the new completion screen with session metadata instead of simply navigating back, and registered the new `tradition/islam-completion` route in the root stack. 

### Testing
- Ran `npm run lint` which failed due to pre-existing unrelated Prettier issues in files outside this change set and not introduced by these changes. (failed) 
- Ran `npx prettier --write` on the modified files and `npx eslint` against the changed files; formatting and targeted linting completed successfully. (succeeded) 
- Started the dev server with `npm run web` and attempted an automated Playwright screenshot for visual verification but the headless browser capture timed out in this environment. (timed out)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4cdfced988323ac8a4ea111cb22da)