### PR TITLE
feat(buddhist-prayer): align focus-gate completion and AR merit note parity

### DIFF
--- a/app/tradition/buddhist-prayer/ar-completion.tsx
+++ b/app/tradition/buddhist-prayer/ar-completion.tsx
@@ -14,6 +14,7 @@ import {
 import { useChantSession } from '@/hooks/use-chant-session';
 import { useBuddhistPrayerStore } from '@/hooks/use-buddhist-prayer-store';
 import { formatDuration } from '@/lib/chant-helpers';
+import { recordPrayerCompletion } from '@/lib/focus-gate';
 
 export default function ARCompletionScreen() {
   const router = useRouter();
@@ -27,6 +28,7 @@ export default function ARCompletionScreen() {
     if (!completedRef.current) {
       completedRef.current = true;
       completeSession();
+      void recordPrayerCompletion();
     }
   }, [completeSession]);
 

--- a/app/tradition/buddhist-prayer/ar-merit.tsx
+++ b/app/tradition/buddhist-prayer/ar-merit.tsx
@@ -1,6 +1,6 @@
 import { Stack, useRouter } from 'expo-router';
 import React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
 
 import {
   BuddhistAltar3D,
@@ -38,8 +38,14 @@ const MERIT_OPTIONS: { option: MeritOption; label: string; description: string }
 
 export default function ARMeritScreen() {
   const router = useRouter();
-  const { meritOption, placementScale, placementRotation, selectMeritOption } =
-    useBuddhistPrayerStore();
+  const {
+    dedicationNote,
+    meritOption,
+    placementScale,
+    placementRotation,
+    selectMeritOption,
+    setDedicationNote,
+  } = useBuddhistPrayerStore();
 
   return (
     <View style={styles.container}>
@@ -76,6 +82,20 @@ export default function ARMeritScreen() {
               onSelect={() => selectMeritOption(option)}
             />
           ))}
+        </View>
+
+        <View style={styles.noteSection}>
+          <ThemedText style={styles.noteLabel}>Optional dedication note</ThemedText>
+          <TextInput
+            style={styles.noteInput}
+            value={dedicationNote}
+            onChangeText={setDedicationNote}
+            placeholder="Offer a name, prayer, or intention…"
+            placeholderTextColor={BuddhistPrayerColors.textMuted}
+            multiline
+            numberOfLines={3}
+            textAlignVertical="top"
+          />
         </View>
 
         <GoldButton
@@ -120,5 +140,27 @@ const styles = StyleSheet.create({
   },
   optionsList: {
     gap: BuddhistPrayerSpacing.sm,
+  },
+  noteSection: {
+    gap: BuddhistPrayerSpacing.xs,
+  },
+  noteLabel: {
+    color: BuddhistPrayerColors.textSecondary,
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  noteInput: {
+    minHeight: 112,
+    backgroundColor: BuddhistPrayerColors.card,
+    borderWidth: 1,
+    borderColor: BuddhistPrayerColors.cardBorder,
+    borderRadius: 18,
+    paddingHorizontal: BuddhistPrayerSpacing.md,
+    paddingVertical: BuddhistPrayerSpacing.sm,
+    color: BuddhistPrayerColors.textPrimary,
+    fontSize: 14,
+    lineHeight: 22,
   },
 });

--- a/app/tradition/buddhist-prayer/completion.tsx
+++ b/app/tradition/buddhist-prayer/completion.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/constants/buddhist-prayer/theme';
 import { useChantSession } from '@/hooks/use-chant-session';
 import { formatDuration } from '@/lib/chant-helpers';
+import { recordPrayerCompletion } from '@/lib/focus-gate';
 
 export default function CompletionScreen() {
   const router = useRouter();
@@ -24,6 +25,7 @@ export default function CompletionScreen() {
     if (!completedRef.current) {
       completedRef.current = true;
       completeSession();
+      void recordPrayerCompletion();
     }
   }, [completeSession]);
 


### PR DESCRIPTION
### Motivation
- Ensure cross-tradition consistency by adding the same focus-gate completion tracking used in Christian and legacy flows to the Buddhist completion screens. 
- Bring the AR merit flow to parity with the standard Buddhist merit flow by adding the optional dedication note input so users can record dedications in AR mode.

### Description
- Add `recordPrayerCompletion()` import and call to the Buddhist standard completion screen (`app/tradition/buddhist-prayer/completion.tsx`) to record focus-gate completion when the session completes. 
- Add `recordPrayerCompletion()` import and call to the Buddhist AR completion screen (`app/tradition/buddhist-prayer/ar-completion.tsx`) for parity in completion tracking. 
- Extend the AR merit screen (`app/tradition/buddhist-prayer/ar-merit.tsx`) with a `TextInput` for the optional dedication note and wire it to the store via `dedicationNote` / `setDedicationNote`, plus matching styles to mirror the standard merit screen.

### Testing
- Ran `npx eslint app/tradition/buddhist-prayer/completion.tsx app/tradition/buddhist-prayer/ar-completion.tsx app/tradition/buddhist-prayer/ar-merit.tsx` which completed successfully. 
- Ran `npm run lint` which failed due to pre-existing `prettier` formatting issues in unrelated files, so the project-wide lint target did not pass but the targeted ESLint check for the modified files is clean.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4e273d0688323ba9c871340be7cb4)